### PR TITLE
fix(og-image): add missing await for async post fetch

### DIFF
--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -14,7 +14,7 @@ export default async function Image({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const post = getDocumentBySlug('posts', slug, ['title']);
+  const post = await getDocumentBySlug('posts', slug, ['title']);
   const title = post?.title || 'Blog Post';
 
   return new ImageResponse(


### PR DESCRIPTION
## Summary
Fixed OG image metadata generation for blog posts. The `getDocumentBySlug` function is async but wasn't being awaited, causing the post title to be undefined and falling back to a generic "Blog Post" string.

## Changes
Added `await` keyword to properly resolve the Promise and fetch the blog post title for OG image metadata.

## Testing
- TypeScript compilation passes
- Change verified against git diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blog post metadata retrieval reliability to ensure data is properly resolved before processing, enhancing overall system stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->