### PR TITLE
feat(og-image): add generateStaticParams for static generation

### DIFF
--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,5 +1,10 @@
 import { ImageResponse } from 'next/og';
-import { getDocumentBySlug } from 'outstatic/server';
+import { getDocumentBySlug, getDocumentSlugs } from 'outstatic/server';
+
+export async function generateStaticParams() {
+  const posts = getDocumentSlugs('posts');
+  return posts.map((slug) => ({ slug }));
+}
 
 export const alt = 'Blog Post';
 export const size = {


### PR DESCRIPTION
## Summary
Added `generateStaticParams` to the OG image component to ensure blog post OG images are pre-generated at build time for each slug.

## Problem
Without `generateStaticParams`, Next.js couldn't determine which routes to pre-render in static mode, causing OG images to fail in production while working locally.

## Changes
- Added `generateStaticParams` export that fetches all blog post slugs
- Ensures each blog post's OG image is generated with the correct title at build time