### PR TITLE
fix(guestbook): include credentials in API requests

### DIFF
--- a/src/app/guestbook/guestbook-header.tsx
+++ b/src/app/guestbook/guestbook-header.tsx
@@ -10,15 +10,17 @@ import { SignDialog } from './sign-dialog';
 export function GuestbookHeader() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { data: session, isPending: isSessionLoading } = useSession();
+
+  // Only check eligibility after we confirm the user is authenticated
+  const isAuthenticated = !isSessionLoading && !!session?.user;
   const {
     data: eligibility,
     isLoading: isEligibilityLoading,
     isError: isEligibilityError,
     refetch: refetchEligibility,
-  } = useGuestbookEligibility();
+  } = useGuestbookEligibility(isAuthenticated);
 
-  const isLoading = isSessionLoading || isEligibilityLoading;
-  const isAuthenticated = !!session?.user;
+  const isLoading = isSessionLoading || (isAuthenticated && isEligibilityLoading);
   const canSign = eligibility?.eligible ?? false;
 
   return (

--- a/src/lib/api/guestbook.ts
+++ b/src/lib/api/guestbook.ts
@@ -16,6 +16,7 @@ async function fetchApi<T>(
 ): Promise<T> {
   const response = await fetch(`/api/guestbook${endpoint}`, {
     ...options,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       ...options?.headers,

--- a/src/lib/hooks/use-guestbook.ts
+++ b/src/lib/hooks/use-guestbook.ts
@@ -34,11 +34,12 @@ export function useGuestbookPosts() {
   });
 }
 
-export function useGuestbookEligibility() {
+export function useGuestbookEligibility(enabled: boolean = true) {
   return useQuery({
     queryKey: guestbookKeys.eligibility(),
     queryFn: checkEligibility,
     staleTime: 5 * 60 * 1000, // 5 minutes
+    enabled,
   });
 }
 


### PR DESCRIPTION
## Summary
- Fix authentication mismatch bug where the client showed user as logged in but the server's eligibility check returned "Not authenticated"
- Add `credentials: 'include'` to fetch calls so session cookies are sent with API requests

## Test plan
- [ ] Log in via GitHub OAuth
- [ ] Verify the "Sign the Guestbook" button appears (instead of "Not authenticated")