### PR TITLE
feat(blog): add table of contents with scroll tracking

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { getDocumentBySlug, getDocumentSlugs } from 'outstatic/server';
 import Markdown from 'react-markdown';
 
 import CodeSection from '@/app/blog/[slug]/code-section';
+import { TableOfContents } from '@/components/table-of-contents';
+import { extractHeadings, slugify } from '@/lib/extract-headings';
 
 import BackButton from './back-button';
 
@@ -60,8 +62,11 @@ const BlogDetailPage = async (props0: Props) => {
     return notFound();
   }
 
+  const headings = extractHeadings(post.content);
+
   return (
-    <div className="px-5 mx-auto max-w-3xl">
+    <div className="relative px-5 mx-auto max-w-3xl">
+      <TableOfContents headings={headings} />
       <BackButton className="mt-10" />
       <div className="mt-10 text-xl font-bold md:text-3xl">{post.title}</div>
       <div className="mt-2 text-sm text-gray-500">
@@ -97,14 +102,20 @@ const BlogDetailPage = async (props0: Props) => {
             h1({ node, ...props }) {
               return <h1 className="text-black font-semibold" {...props} />;
             },
-            h2({ node, ...props }) {
-              return <h2 className="text-black font-semibold" {...props} />;
+            h2({ node, children, ...props }) {
+              const text = String(children);
+              const id = slugify(text);
+              return <h2 id={id} className="text-black font-semibold scroll-mt-20" {...props}>{children}</h2>;
             },
-            h3({ node, ...props }) {
-              return <h3 className="mb-0 text-black font-semibold" {...props} />;
+            h3({ node, children, ...props }) {
+              const text = String(children);
+              const id = slugify(text);
+              return <h3 id={id} className="mb-0 text-black font-semibold scroll-mt-20" {...props}>{children}</h3>;
             },
-            h4({ node, ...props }) {
-              return <h4 className="text-black font-medium" {...props} />;
+            h4({ node, children, ...props }) {
+              const text = String(children);
+              const id = slugify(text);
+              return <h4 id={id} className="text-black font-medium scroll-mt-20" {...props}>{children}</h4>;
             },
             h5({ node, ...props }) {
               return <h5 className="text-black font-medium" {...props} />;

--- a/src/components/table-of-contents.tsx
+++ b/src/components/table-of-contents.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { TOCHeading } from '@/lib/extract-headings';
+
+interface TableOfContentsProps {
+  headings: TOCHeading[];
+}
+
+export function TableOfContents({ headings }: TableOfContentsProps) {
+  const [activeId, setActiveId] = useState<string>('');
+
+  useEffect(() => {
+    const observers: IntersectionObserver[] = [];
+
+    headings.forEach(({ id }) => {
+      const element = document.getElementById(id);
+      if (!element) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              setActiveId(id);
+            }
+          });
+        },
+        {
+          rootMargin: '-80px 0px -80% 0px',
+          threshold: 0,
+        }
+      );
+
+      observer.observe(element);
+      observers.push(observer);
+    });
+
+    return () => {
+      observers.forEach((observer) => observer.disconnect());
+    };
+  }, [headings]);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+    e.preventDefault();
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  if (headings.length < 3) {
+    return null;
+  }
+
+  return (
+    <nav
+      className="hidden xl:block fixed top-32 w-48"
+      style={{ left: 'max(16px, calc(50% - 384px - 256px))' }}
+    >
+      <ul className="space-y-0">
+        {headings.map(({ id, text, level }, index) => {
+          const isActive = activeId === id;
+          const isLast = index === headings.length - 1;
+
+          return (
+            <li key={id}>
+              <a
+                href={`#${id}`}
+                onClick={(e) => handleClick(e, id)}
+                className={`
+                  block py-3 text-sm transition-colors duration-200
+                  ${level === 3 ? 'pl-4' : level === 4 ? 'pl-8' : ''}
+                  ${!isLast ? 'border-b border-gray-200' : ''}
+                  ${isActive ? 'text-black font-semibold' : 'text-gray-400 hover:text-gray-600'}
+                `}
+              >
+                {text}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/lib/extract-headings.ts
+++ b/src/lib/extract-headings.ts
@@ -15,16 +15,22 @@ export function slugify(text: string): string {
  * Extract headings from markdown content
  */
 export function extractHeadings(content: string): TOCHeading[] {
+  const contentWithoutCode = content.replace(/```[\s\S]*?```/g, '');
   const headingRegex = /^(#{2,4})\s+(.+)$/gm;
   const headings: TOCHeading[] = [];
+  const idCounts = new Map<string, number>();
   let match;
 
-  while ((match = headingRegex.exec(content)) !== null) {
+  while ((match = headingRegex.exec(contentWithoutCode)) !== null) {
     const level = match[1].length as 2 | 3 | 4;
     const text = match[2].trim();
-    const id = slugify(text);
+    const baseId = slugify(text) || 'heading';
 
-    headings.push({ id, text, level });
+    const count = idCounts.get(baseId) || 0;
+    idCounts.set(baseId, count + 1);
+    const uniqueId = count === 0 ? baseId : `${baseId}-${count}`;
+
+    headings.push({ id: uniqueId, text, level });
   }
 
   return headings;

--- a/src/lib/extract-headings.ts
+++ b/src/lib/extract-headings.ts
@@ -1,0 +1,31 @@
+export interface TOCHeading {
+  id: string;
+  text: string;
+  level: 2 | 3 | 4;
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+/**
+ * Extract headings from markdown content
+ */
+export function extractHeadings(content: string): TOCHeading[] {
+  const headingRegex = /^(#{2,4})\s+(.+)$/gm;
+  const headings: TOCHeading[] = [];
+  let match;
+
+  while ((match = headingRegex.exec(content)) !== null) {
+    const level = match[1].length as 2 | 3 | 4;
+    const text = match[2].trim();
+    const id = slugify(text);
+
+    headings.push({ id, text, level });
+  }
+
+  return headings;
+}


### PR DESCRIPTION
## Summary

Add a minimal, Anthropic-style table of contents to blog posts that tracks scroll position and highlights the active section.

## Changes

- Add `TableOfContents` client component with IntersectionObserver-based scroll tracking
- Add `extractHeadings` utility to parse H2, H3, H4 headings from markdown
- Add IDs to rendered headings for anchor navigation
- Position TOC as fixed sidebar on left (visible on xl screens only)
- Only show TOC when post has 3+ headings

## Type of Change

- [x] feat: New feature

## Testing

- Verified build passes
- Tested locally with blog posts containing multiple headings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a dynamic table of contents for blog posts when multiple sections exist.
  * Generates stable in-page anchors for subheadings to enable direct linking.
  * Highlights the active section as you scroll.
  * Smooth scrolling when selecting items in the table of contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->